### PR TITLE
chore: align renovate config with library defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,15 @@ categories = ["api-bindings"]
 
 [dependencies]
 bon = "3"
-serde = { version = "^1.0", features = ["derive"] }
-serde_with = { version = "^3.8", default-features = false, features = ["base64", "std", "macros"] }
-serde_json = "^1.0"
-serde_repr = "^0.1"
-url = "^2.5"
-tokio = { version = "^1.46.0", features = ["fs"] }
-tokio-util = { version = "^0.7", features = ["codec"] }
-reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart", "stream"] }
-reqwest-middleware = { version = "^0.4", features = ["json", "multipart"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_with = { version = "3.8", default-features = false, features = ["base64", "std", "macros"] }
+serde_json = "1.0"
+serde_repr = "0.1"
+url = "2.5"
+tokio = { version = "1.46.0", features = ["fs"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "stream"] }
+reqwest-middleware = { version = "0.4", features = ["json", "multipart"] }
 
 [dev-dependencies]
 anyhow = "1"

--- a/renovate.json5
+++ b/renovate.json5
@@ -40,6 +40,14 @@
   ],
 
   // Vulnerability alerts
-  "vulnerabilityAlerts": { "enabled": true, "labels": ["security"], "prPriority": 100 }
-}
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "assignees": ["timvw"]
+  },
 
+  "rust": {
+    "enabled": true,
+    "rangeStrategy": "update-lockfile"  // Update Cargo.lock while keeping flexible Cargo.toml ranges
+  }
+}


### PR DESCRIPTION
## Summary
- align Renovate rust range strategy with other libraries
- relax Cargo dependency requirements to maintain semver compatibility

## Testing
- npx -y --package renovate renovate-config-validator renovate.json5