### PR TITLE
fix(generate): unblock client generation for the grown OpenAI spec

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -18,6 +18,11 @@ GEN_SPEC_DIR="$PROJECT_ROOT/target/specs"
 SPEC_IN="$PROJECT_ROOT/stainless.yaml"
 SPEC_MODEL_FIXED="$GEN_SPEC_DIR/l1_model_fixed.yaml"
 SPEC_OUT="$GEN_SPEC_DIR/l2_rust_compatible.yaml"
+# JSON form of the final spec fed to the generator: the OpenAPI 3.1 $ref
+# dereferencer parses YAML through snakeyaml, which aborts once the document
+# exceeds 3145728 code points ("The incoming YAML document exceeds the limit").
+# The Stainless spec has grown past that; JSON parsing has no such limit.
+SPEC_OUT_JSON="$GEN_SPEC_DIR/l2_rust_compatible.json"
 OUT_DIR="$PROJECT_ROOT"
 
 # Ensure target directories exist
@@ -67,6 +72,12 @@ uv run --with pyyaml python "$SCRIPT_DIR/patch_spec_rust_compat.py" "$SPEC_MODEL
 echo "  Layer 2b: Replacing missing schema references with free-form objects..."
 uv run --with pyyaml python "$SCRIPT_DIR/replace_missing_schema_refs.py" "$SPEC_OUT"
 
+# Convert the final spec to JSON for the generator (see SPEC_OUT_JSON note above):
+# snakeyaml's 3 MiB code-point limit aborts the OpenAPI 3.1 $ref dereferencer on
+# the (now larger) spec, so we feed JSON instead, which has no such limit.
+echo "  Converting final spec to JSON..."
+uv run --with pyyaml python -c "import sys, json, yaml; json.dump(yaml.safe_load(open(sys.argv[1])), open(sys.argv[2], 'w'), default=str)" "$SPEC_OUT" "$SPEC_OUT_JSON"
+
 # Step 3: Generate Rust client
 echo ""
 echo "🦀 Generating Rust client..."
@@ -86,10 +97,12 @@ find "$OUT_DIR" -name "*.rs" -not -name "lib.rs" -delete 2>/dev/null || true
 rm -rf "$OUT_DIR/docs" 2>/dev/null || true
 
 # Run OpenAPI Generator via Docker
-GENERATOR_CMD="docker run --rm -v $PROJECT_ROOT:/local -u $(id -u):$(id -g) -e JAVA_OPTS=-Dlog.level=${OPENAPI_GENERATOR_LOG_LEVEL} openapitools/openapi-generator-cli:v${OPENAPI_GENERATOR_VERSION}"
-
-$GENERATOR_CMD generate \
-    -i "/local/target/specs/l2_rust_compatible.yaml" \
+docker run --rm \
+    -v "$PROJECT_ROOT:/local" \
+    -u "$(id -u):$(id -g)" \
+    -e JAVA_OPTS="-Dlog.level=${OPENAPI_GENERATOR_LOG_LEVEL}" \
+    "openapitools/openapi-generator-cli:v${OPENAPI_GENERATOR_VERSION}" generate \
+    -i "/local/target/specs/l2_rust_compatible.json" \
     -g rust \
     -o "/local" \
     --skip-validate-spec \

--- a/scripts/patch_spec_rust_compat.py
+++ b/scripts/patch_spec_rust_compat.py
@@ -131,7 +131,14 @@ def add_titles_to_unnamed_union_variants(node, path=""):
                             item["title"] = "Boolean"
                         elif t == "array":
                             items_schema = item.get("items", {})
-                            inner_type = items_schema.get("type", "item").capitalize()
+                            # Prefer the referenced schema name so that a union of
+                            # several array-of-$ref variants gets distinct titles
+                            # (otherwise they all collapse to "ArrayOfItems", which
+                            # yields duplicate Rust enum variants that fail to compile).
+                            if "$ref" in items_schema:
+                                inner_type = items_schema["$ref"].split("/")[-1]
+                            else:
+                                inner_type = items_schema.get("type", "item").capitalize()
                             item["title"] = f"ArrayOf{inner_type}s"
                         elif t == "object":
                             item["title"] = f"Object{i}"

--- a/scripts/simplified_schemas.py
+++ b/scripts/simplified_schemas.py
@@ -14,6 +14,13 @@ SIMPLIFIED_SCHEMAS: Set[str] = {
     "ModelIds",
     "ModelIdsShared",
     "ModelIdsResponses",
+    # Beta analogs of the model-id wrapper schemas above. Like the non-Beta
+    # ones they must be flattened to plain strings; otherwise the generator
+    # emits enums with invalid Rust identifiers (e.g. `gpt-5.1-codex-max`
+    # becomes the variant `Gpt5.1CodexMax`, which does not compile).
+    "BetaModelIdsShared",
+    "BetaModelIdsResponses",
+    "BetaModelIdsCompaction",
     "CreateCompletionRequestModel",
     "CreateAssistantRequestModel",
     "CreateThreadAndRunRequestModel",


### PR DESCRIPTION
## Problem

The nightly **Generate Client** workflow ([run #29072533050](https://github.com/genai-rs/openai-client-base/actions/runs/29072533050)) fails. The OpenAI/Stainless spec (now v2.3.0) grew and added new `Beta*` schemas, producing three cascading failures:

1. **Parse (the reported CI failure):** the patched spec exceeds snakeyaml's default `3145728` code-point (3 MiB) limit. The OpenAPI 3.1 `$ref` dereferencer aborts with *"The incoming YAML document exceeds the limit"*, leaving `openAPI` null → `NullPointerException`. (`-DmaxYamlCodePoints` does **not** cover the dereferencer code path.)
2. **Invalid enum identifiers:** new `BetaModelIds*` schemas aren't flattened to strings, so `gpt-5.1-codex-max` generates the variant `Gpt5.1CodexMax` — invalid Rust.
3. **Duplicate enum variants:** the new `oneOf`-of-arrays union `BetaOutputTextContentParamAnnotations` gets three members all auto-titled `ArrayOfItems` → duplicate `Arrayofitems` variants → won't compile.

CI only surfaced #1 (it dies at parse); #2 and #3 would block the `cargo build`/`clippy` verify step immediately after.

## Fix (3 scripts, +32/−5)

- **`scripts/generate.sh`** — convert the final patched spec to JSON and feed JSON to the openapi-generator (JSON parsing has no code-point limit); tidy the `docker run` invocation.
- **`scripts/simplified_schemas.py`** — add `BetaModelIdsShared` / `BetaModelIdsResponses` / `BetaModelIdsCompaction` to the string-flattening set.
- **`scripts/patch_spec_rust_compat.py`** — derive array-union variant titles from the referenced schema name instead of the generic `"item"` fallback.

## Verification

Ran the full pipeline end-to-end locally plus the workflow's verify commands — all green:

- `generate.sh` → exit 0, 0 YAML-limit errors, 0 invalid identifiers
- `cargo build --all-features` ✅
- `cargo clippy --all-features --all-targets -- -D warnings` ✅
- `cargo test --all-features` ✅

Reviewed by codex (`codex exec`) — no actionable findings.